### PR TITLE
Increase popover size to match ContentView

### DIFF
--- a/Vitals/AppDelegate.swift
+++ b/Vitals/AppDelegate.swift
@@ -23,7 +23,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Note: we _don't_ want to make the popover's behaviour "transient" as we handle all the click
         // detection ourselves in the StatusBarController, which gives us more control
-        popover.contentSize = NSSize(width: 400, height: 360)
+        popover.contentSize = NSSize(width: 400, height: 492)
         // Put the SwiftUI content inside the popover
         popover.contentViewController = NSHostingController(rootView: contentView)
         popover.animates = false


### PR DESCRIPTION
Fixes #7 on macOS 11 (Big Sur).

<img width="472" alt="Screenshot 2021-03-25 at 00 11 56" src="https://user-images.githubusercontent.com/18508536/112395514-d6e75a00-8cfe-11eb-8f9b-33ef31a2a520.png">

This is quite a straight-forward fix for the height issue, it just sets ```popover.contentSize```'s height to 492. This is equal to (20 process name heights * 16 px) + (19 VStack spacing * 8 px) + (2 VStack padding * 10 px).

It unfortunately introduces some coupling but, from my testing, it seems unavoidable if we want to avoid scrolling. From what I've seen online, the alternative would be calling ```VStack.fixedSize(horizontal: false, vertical: true)``` to avoid clipping height, but in my tests this bizarrely sets the NSHostingView height to 4284 px...

<img width="1280" alt="Screenshot 2021-03-25 at 00 07 19" src="https://user-images.githubusercontent.com/18508536/112395159-2d07cd80-8cfe-11eb-8af5-8f947cace68d.png">
