### PR TITLE
Fix ResourceType cycle buttons for dark mode on macOS 11+

### DIFF
--- a/Vitals/ContentView.swift
+++ b/Vitals/ContentView.swift
@@ -120,10 +120,17 @@ struct ContentView: View {
                             // Extra rectangle to increase the size of the click target
                             Rectangle().frame(width: 14, height: 16, alignment: .center).opacity(0.0)
                             
-                            Image("chevron-left")
-                                .resizable()
-                                .scaledToFit()
-                                .frame(maxHeight: 12)
+                            if #available(macOS 11.0, *) {
+                                Image(systemName: "chevron.left")
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(maxHeight: 12)
+                            } else {
+                                Image("chevron-left")
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(maxHeight: 12)
+                            }
                         }
                     }.buttonStyle(BorderlessButtonStyle())
                     .frame(width: 14, height: 16, alignment: .center)
@@ -135,10 +142,17 @@ struct ContentView: View {
                             // Extra rectangle to increase the size of the click target
                             Rectangle().frame(width: 14, height: 16, alignment: .center).opacity(0.0)
                             
-                            Image("chevron-right")
-                                .resizable()
-                                .scaledToFit()
-                                .frame(maxHeight: 12)
+                            if #available(macOS 11.0, *) {
+                                Image(systemName: "chevron.right")
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(maxHeight: 12)
+                            } else {
+                                Image("chevron-right")
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(maxHeight: 12)
+                            }
                         }
                     }.buttonStyle(BorderlessButtonStyle())
                     .frame(width: 14, height: 16, alignment: .center)


### PR DESCRIPTION
Hello! Thanks for Vitals.

I noticed that the two buttons to cycle between resources don't look good on dark mode with a dark background. I replaced the images with the same SF symbols when on macOS 11+ ([docs](https://developer.apple.com/documentation/swiftui/image/init(systemname:))), which adapt to the theme used.


| Before   |      After |
| :--------: | ---------: |
| <img width="918" alt="screenshot_2021-08-08_22-22-27" src="https://user-images.githubusercontent.com/11699655/128644653-ef97e3ff-2f29-42b3-bb6b-9c2b9e33687a.png"> | <img width="939" alt="screenshot_2021-08-08_22-22-32" src="https://user-images.githubusercontent.com/11699655/128644651-fcef2286-aa20-445c-b347-2c328ae1be77.png"> |